### PR TITLE
Fix deadlock scenario

### DIFF
--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -113,21 +113,15 @@ func (store *metricStore) collect(metrics []metric) []metric {
 }
 
 func (store *metricStore) cleanup(exp time.Time) {
-	store.mutex.RLock()
+	store.mutex.Lock()
 
 	for name, entry := range store.entries {
-		store.mutex.RUnlock()
-
 		entry.cleanup(exp, func() {
-			store.mutex.Lock()
 			delete(store.entries, name)
-			store.mutex.Unlock()
 		})
-
-		store.mutex.RLock()
 	}
 
-	store.mutex.RUnlock()
+	store.mutex.Unlock()
 }
 
 type metricEntry struct {


### PR DESCRIPTION
In the event that `cleanup` is being called, and a stat is being incremented, and stats are being polled all at the same time, there is a potential deadlock scenario.  We hit this a few times in a production environment.

Basically
1. In `cleanup` a write lock on the store is waiting [here](https://github.com/segmentio/stats/blob/bed3e7999fc380a619874a505a0c55efcf520777/prometheus/metric.go#L122)
2. It is waiting because a read lock on the store is being held by [collect](https://github.com/segmentio/stats/blob/bed3e7999fc380a619874a505a0c55efcf520777/prometheus/metric.go#L105).
3. That read lock is still being held, and that code is now attempting to get a [read lock](https://github.com/segmentio/stats/blob/bed3e7999fc380a619874a505a0c55efcf520777/prometheus/metric.go#L105) on the entry.
4. However, that entry has a [write lock held](https://github.com/segmentio/stats/blob/bed3e7999fc380a619874a505a0c55efcf520777/prometheus/metric.go#L105) by `#1`.  Hence it will be stuck, and `#1` will be stuck.  Deadlock.